### PR TITLE
Fix a few errors to build the release binaries of the game in CLion with VS 2019 compiler.

### DIFF
--- a/src/cpp/SceneScript.cpp
+++ b/src/cpp/SceneScript.cpp
@@ -1,5 +1,6 @@
 #include <SceneScript.hpp>
 #include <characters/Pig.hpp>
+#include <stdexcept>
 
 AbstractSceneHandler::AbstractSceneHandler()
     : finished(false)

--- a/src/cpp/main.cpp
+++ b/src/cpp/main.cpp
@@ -1,7 +1,7 @@
 #include <GameHandler.hpp>
 #include <sdl_wrappers.hpp>
 
-int main()
+int main(int argc, char *argv[])
 {
     SDL_Handler _;
     auto game_handler = GameHandler();


### PR DESCRIPTION
This pull request fixes a few errors to build the release binaries of the game and the map editor in the CLion IDE with the Visual Studio 2019 compiler on MS Windows 10 OS.